### PR TITLE
chat behavior changes

### DIFF
--- a/src/components/Chat.jsx
+++ b/src/components/Chat.jsx
@@ -3,6 +3,7 @@ import { BiChat, BiWindowClose } from 'react-icons/bi';
 import { useNavigate } from 'react-router-dom';
 import { Tooltip } from 'react-tooltip';
 import Markdown from 'react-markdown';
+import useTailwindBreakpoint from './hooks/useTailwindBreakpoint';
 
 const ChatWindow = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -11,6 +12,7 @@ const ChatWindow = () => {
   const [loading, setLoading] = useState(false);
   const bottomRef = useRef(null);
   const navigate = useNavigate();
+  const { breakpoint, isIPad } = useTailwindBreakpoint();
 
   useEffect(() => {
     if (bottomRef.current) {
@@ -125,9 +127,11 @@ const ChatWindow = () => {
         data-tooltip-id="chat-tooltip"
         data-tooltip-html="Chat with my CV here!"
         data-tooltip-place="left"
-        // onClick={() => setIsOpen(!isOpen)}
         onClick={() => {
-          navigate('/chat');
+          if (breakpoint !== 'sm' && breakpoint !== 'md' && !isIPad) {
+            navigate('/chat');
+            return;
+          }
           setIsOpen(!isOpen);
         }}
       >

--- a/src/components/hooks/useTailwindBreakpoint.jsx
+++ b/src/components/hooks/useTailwindBreakpoint.jsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+
+const getTailwindBreakpoint = (width) => {
+  if (width < 640) return 'sm';
+  if (width < 768) return 'md';
+  if (width < 1024) return 'lg';
+  if (width < 1280) return 'xl';
+  if (width < 1536) return '2xl';
+  return 'full';
+};
+
+const isIpad = () => {
+  const ua = navigator.userAgent.toLowerCase();
+  const platform = navigator.platform;
+
+  const isiPadOld = /ipad/.test(ua);
+  const isiPadNew = platform === 'MacIntel' && navigator.maxTouchPoints > 1; // iPadOS reports as Mac now
+
+  return isiPadOld || isiPadNew;
+};
+
+export const useTailwindBreakpointAndDevice = () => {
+  const [breakpoint, setBreakpoint] = useState('');
+  const [isIPad, setIsIPad] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setBreakpoint(getTailwindBreakpoint(window.innerWidth));
+    };
+
+    setIsIPad(isIpad());
+    handleResize();
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return { breakpoint, isIPad };
+};
+
+export default useTailwindBreakpointAndDevice;
+export { useTailwindBreakpointAndDevice as useTailwindBreakpoint };


### PR DESCRIPTION
This pull request introduces a new custom hook, `useTailwindBreakpointAndDevice`, to enhance responsive design and device-specific logic in the `ChatWindow` component. The changes include adding device and breakpoint detection, and updating the `ChatWindow` behavior based on these conditions.

### New Hook Implementation:
* Created `useTailwindBreakpointAndDevice` in `src/components/hooks/useTailwindBreakpoint.jsx` to detect the current Tailwind CSS breakpoint and whether the device is an iPad. The hook uses `window.innerWidth` for breakpoint detection and user agent checks for iPad identification.

### Integration in `ChatWindow`:
* Imported `useTailwindBreakpoint` in `src/components/Chat.jsx` and used it to retrieve `breakpoint` and `isIPad`. [[1]](diffhunk://#diff-5381e2d1171b80ae36b38102350444e52c59d98c48559a5376860e1ef9883e72R6) [[2]](diffhunk://#diff-5381e2d1171b80ae36b38102350444e52c59d98c48559a5376860e1ef9883e72R15)
* Updated the `onClick` handler for the chat button to navigate to the `/chat` route for devices that are not small or medium breakpoints and are not iPads, otherwise toggling the chat window state.